### PR TITLE
Add custom exception handlers for stream exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,4 @@ kafka/delete-product-topic:
 	/opt/kafka/bin/kafka-topics.sh \
 		--bootstrap-server localhost:9092 \
 		--delete \
-		--topic product \
-		--force
+		--topic product

--- a/kstream/src/main/kotlin/Main.kt
+++ b/kstream/src/main/kotlin/Main.kt
@@ -16,13 +16,7 @@ const val redisNamespaceTotal = "product:in-cart:count-total"
 const val redisNamespaceUnique = "product:in-cart:count-unique"
 
 fun main() {
-    val props = Properties().apply {
-        put(StreamsConfig.APPLICATION_ID_CONFIG, "redis-aggregator")
-        put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
-        put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde::class.java.name)
-        put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, EventSerde::class.java.name)
-        put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-    }
+
 
     val redisClient = RedisClient.create("redis://127.0.0.1:6379")
     val redisConnection = redisClient.connect()
@@ -65,6 +59,22 @@ fun main() {
 
             dumpRedis(redis)
         }
+
+    val props = Properties().apply {
+        put(StreamsConfig.APPLICATION_ID_CONFIG, "redis-aggregator")
+        put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+        put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde::class.java.name)
+        put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, EventSerde::class.java.name)
+        put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+        put(
+            StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
+            CustomDeserializationExceptionHandler::class.java
+        )
+        put(
+            StreamsConfig.DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG,
+            CustomProductionExceptionHandler::class.java
+        )
+    }
 
     val streams = KafkaStreams(builder.build(), props)
 

--- a/kstream/src/main/kotlin/StreamErrorHandler.kt
+++ b/kstream/src/main/kotlin/StreamErrorHandler.kt
@@ -1,0 +1,40 @@
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler
+import org.apache.kafka.streams.errors.ProductionExceptionHandler
+import org.apache.kafka.streams.processor.ProcessorContext
+import java.lang.Exception
+
+class CustomDeserializationExceptionHandler : DeserializationExceptionHandler {
+    override fun handle(
+        context: ProcessorContext?,
+        record: ConsumerRecord<ByteArray?, ByteArray?>?,
+        exception: Exception?
+    ): DeserializationExceptionHandler.DeserializationHandlerResponse {
+        println("====> Deserialization exception")
+        println("💣 $context")
+        println("💣 $record")
+        println("💣 $exception")
+        println("<==== Deserialization exception")
+
+        return DeserializationExceptionHandler.DeserializationHandlerResponse.CONTINUE
+    }
+
+    override fun configure(configs: Map<String?, *>?) {}
+}
+
+class CustomProductionExceptionHandler : ProductionExceptionHandler {
+    override fun handle(
+        record: ProducerRecord<ByteArray?, ByteArray?>?,
+        exception: Exception?
+    ): ProductionExceptionHandler.ProductionExceptionHandlerResponse {
+        println("====> Production exception")
+        println("💣 $record")
+        println("💣 $exception")
+        println("<==== Production exception")
+
+        return ProductionExceptionHandler.ProductionExceptionHandlerResponse.FAIL
+    }
+
+    override fun configure(configs: Map<String?, *>?) {}
+}


### PR DESCRIPTION
**When sending a malformed message into the product topic**

Before (almost looks like a success 😅):

```txt
⭐️ Kafka Streams state changed from REBALANCING to RUNNING
⭐️ Kafka Streams state changed from RUNNING to PENDING_ERROR
⭐️ Kafka Streams state changed from PENDING_ERROR to ERROR

BUILD SUCCESSFUL in 5s
4 actionable tasks: 2 executed, 2 up-to-date
12:18:59: Execution finished ':kstream:MainKt.main()'.
```

After:

```txt
⭐️ Kafka Streams state changed from REBALANCING to RUNNING
====> Deserialization exception
💣 org.apache.kafka.streams.processor.internals.ProcessorContextImpl@6036da59
💣 ConsumerRecord(topic = product, partition = 0, leaderEpoch = 0, offset = 0, CreateTime = 1759832271143, serialized key size = 4, serialized value size = 26, headers = RecordHeaders(headers = [], isReadOnly = false), key = [B@47a5e539, value = [B@4324be95)
💣 kotlinx.serialization.json.internal.JsonDecodingException: Expected JsonObject, but had JsonLiteral as the serialized body of com.example.common.events.Event at element: $
JSON input: Json.encodeToString(event)
<==== Deserialization exception
```

and the app continues to consume messages from the stream 😄 